### PR TITLE
Install geckodriver for linux and fix facebook driver.title

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-if [[ $EUID -eq 0 ]]; then 
+if [[ $EUID -eq 0 ]]; then
 	echo "This script must NOT be run as root" 1>&2
 		exit 1
 	fi
@@ -9,8 +9,26 @@ pip3 install termcolor --user
 pip3 install selenium --user
 pip3 install pyfiglet --user
 mkdir -p ~/.local/bin/
-if [[ ! -x "geckodriver" ]]
-then
-	chmod +x geckodriver
+
+# Install geckodriver on linux machines (64-bit or 32-bit)
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+	if [ `getconf LONG_BIT` = "64" ]
+	then
+		printf "Downloading geckodriver for linux64\n"
+		wget https://github.com/mozilla/geckodriver/releases/download/v0.24.0/geckodriver-v0.24.0-linux64.tar.gz -q --show-progress
+		tar -xvzf geckodriver-v0.24.0-linux64.tar.gz
+		chmod +x geckodriver
+
+	else
+		printf "Downloading geckodriver for linux32\n"
+		wget https://github.com/mozilla/geckodriver/releases/download/v0.24.0/geckodriver-v0.24.0-linux32.tar.gz -q --show-progress
+		tar -xvzf geckodriver-v0.24.0-linux32.tar.gaz
+		chmod +x geckodriver
+	fi
+	mv geckodriver ~/.local/bin/
+	printf "\n[*] Setup completed\n\n"
+	printf "Usage: python3 check.py email@gmail.com or ./check.py email@gmail.com\n\n"
+	exit 1
 fi
+
 mv geckodriver ~/.local/bin/geckodriver

--- a/sites.py
+++ b/sites.py
@@ -101,7 +101,7 @@ def facebookCheck(email):
         result = "Site could not be reached, try again"
         return result
     try:
-        assert "Forgot Password" in driver.title
+        assert "Forgotten Password | Can't Log In | Faceboook" in driver.title
     except AssertionError:
         result = "Site could not be loaded properly, try again"
         return result
@@ -175,5 +175,3 @@ def twitchCheck(email):
     else:
         result = "Found"
         return result
-
-


### PR DESCRIPTION
Hi! 

For starters, I love this project :) Thanks for working on it!

- While running it for the first time on my Debian 9 (64-bit) box, I encountered an error with geckodriver which was the unmet dependency. So my addition to `setup.sh` is to check if the host OS is linux based, 32 or 36-bit, and then download the corresponding geckodriver version from mozilla's releases.
- Choice of printf vs echo: echo's newlines are not consistent across linux OS versions and in some cases appends "\n" instead.
- Encountered the "Site could not be loaded properly, try again" exception for Facebook in `sites.py`. I Changed the `driver.title` after Facebook's latest change.

This is my first ever pull request, so please let me know if and how I can improve in my communication or if I've messed up.

Best,
Snehan